### PR TITLE
Fix sha512-gen output file format

### DIFF
--- a/validate/validate_io.py
+++ b/validate/validate_io.py
@@ -210,7 +210,7 @@ def create_checksum_file(path, hash_type):
         if hash_type == 'md5-gen':
             file.write(generate_md5(path))  
         elif hash_type == 'sha512-gen':
-            file.write(generate_sha512(path))
+            file.write(generate_sha512(path)+'  '+str(path)+'\n')
         else:
             raise IOError('Incorrect hash parameters')
         file.close()

--- a/validate/validate_io.py
+++ b/validate/validate_io.py
@@ -208,7 +208,7 @@ def create_checksum_file(path, hash_type):
     try:
         file = open(str(path) +  ext, "w")
         if hash_type == 'md5-gen':
-            file.write(generate_md5(path))  
+            file.write(generate_md5(path)+'  '+str(path)+'\n')  
         elif hash_type == 'sha512-gen':
             file.write(generate_sha512(path)+'  '+str(path)+'\n')
         else:


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->
## Checklist 

### Formatting

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)-[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

### File Updates

- [ ] I have ensured that the version number update follows the [versioning standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Docker+image+versioning+standardization).

- [ ] I have updated the version number/dependencies and added my name to the maintainer list in the `Dockerfile`.

- [ ] I have updated the version number/feature changes in the `README.md`.

<!--- This acknowledgement is optional if you do not want to be listed--->
- [ ] I have updated the version number and added my name to the contributors list in the `metadata.yaml`.

- [ ] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

<!---If any previous versions have bugs, add "deprecated" in the version tag and list the bug in the corresponding release--->
- [ ] I have drafted the new version release with any additions/changes and have linked the `CHANGELOG.md` in the release. 

### Docker Hub Auto Build Rules

- [ ] I have created automated build rules following [this page](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/How+to+set+up+automated+builds+for+Docker+Hub) and I have not manually pushed this Docker image to the `blcdsdockerregistry` on [Docker Hub](https://hub.docker.com).

### Docker Image Testing

- [X] I have tested the Docker image with the `docker run` command as described below.

#### Test the Docker image with at least one sample. Verify the new Docker image works using:

```docker run -u $(id -u):$(id -g) –w <working-directory> -v <directory-you-want-to-mount>:<how-you-want-to-mount-it-within-the-docker> --rm <docker-image-name> <command-to-the-docker-with-all-parameters>```

#### My command: 

```docker build -t test-pipeval . -f docker/Dockerfile```
```docker run --rm test-pipeval /bin/bash -c "echo 'hello world' > foo.txt; python -m validate -t sha512-gen foo.txt; cat foo.txt.sha512"```

#### Output:
```
sha512-generated for foo.txt
Input: foo.txt is valid sha512-gen
db3974a97f2407b7cae1ae637c0030687a11913274d578492558e39c16c017de84eacdc8c62fe34ee4e12b4b1428817f09b6a2760c3f8a664ceae94d2434a593  foo.txt
```

## Description

<!--- Briefly describe the changes included in this pull request
 !--- starting with 'Closes #...' if approriate --->

Closes #28. Changed sha512-gen output file of create_checksum_file to match output format of "sha512" command.