### PR TITLE
Update to bl-base:1.1.0 and add 'bldocker'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ---
 
 ## [Unreleased]
-### Changed
-- Changed something but it is not part of the last release.
+### Updated
+- Updated bl-base to 1.1.0
+- Installed tools using `mamba`
+
+### Added
+- Add `bldocker` user and group to Dockerfile
 
 ---
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
-FROM blcdsdockerregistry/bl-base:1.0.0 AS builder
+FROM blcdsdockerregistry/bl-base:1.1.0 AS builder
 
 # Use conda to install tools and dependencies into /usr/local
 ARG SAMTOOLS_VERSION=1.11
 ARG VCFTOOLS_VERSION=0.1.16
-RUN conda create -qy -p /usr/local \
+RUN mamba create -qy -p /usr/local \
     -c bioconda \
     -c conda-forge \
     samtools==${SAMTOOLS_VERSION} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,4 +28,11 @@ RUN pip install -r requirements.txt
 # add tool folder to path
 ENV PYTHONPATH "${PYTHONPATH}:/tool/"
 
+# Add a new user/group called bldocker
+RUN groupadd -g 500001 bldocker && \
+    useradd -r -u 500001 -g bldocker bldocker
+
+# Change the default user to bldocker from root
+USER bldocker
+
 LABEL maintainer="Arpi Beshlikyan <abeshlikyan@mednet.ucla.edu>"


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->
## Checklist 

### Formatting

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

- [X] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

### File Updates

- [ ] I have ensured that the version number update follows the [versioning standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Docker+image+versioning+standardization).

- [ ] I have updated the version number/dependencies and added my name to the maintainer list in the `Dockerfile`.

- [ ] I have updated the version number/feature changes in the `README.md`.

<!--- This acknowledgement is optional if you do not want to be listed--->
- [X] I have updated the version number and added my name to the contributors list in the `metadata.yaml`.

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

<!---If any previous versions have bugs, add "deprecated" in the version tag and list the bug in the corresponding release--->
- [ ] I have drafted the new version release with any additions/changes and have linked the `CHANGELOG.md` in the release. 

### Docker Hub Auto Build Rules

- [ ] I have created automated build rules following [this page](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/How+to+set+up+automated+builds+for+Docker+Hub) and I have not manually pushed this Docker image to the `blcdsdockerregistry` on [Docker Hub](https://hub.docker.com).

### Docker Image Testing

- [X] I have tested the Docker image with the `docker run` command as described below.

#### Test the Docker image with at least one sample. Verify the new Docker image works using:

```docker run -u $(id -u):$(id -g) –w <working-directory> -v <directory-you-want-to-mount>:<how-you-want-to-mount-it-within-the-docker> --rm <docker-image-name> <command-to-the-docker-with-all-parameters>```

#### My command: 

```docker build -t test-pipeval . -f docker/Dockerfile```
```docker run -it --rm test-pipeval /bin/bash -c "samtools --version; vcftools --version; tabix --version; pip --version; whoami; groups;"```

#### Output: 
```
samtools 1.11
Using htslib 1.11
Copyright (C) 2020 Genome Research Ltd.
VCFtools (0.1.16)
tabix (htslib) 1.11
Copyright (C) 2020 Genome Research Ltd.
pip 22.0.4 from /usr/local/lib/python3.10/site-packages/pip (python 3.10)
bldocker
bldocker
```

## Description

<!--- Briefly describe the changes included in this pull request
 !--- starting with 'Closes #...' if approriate --->

Updates bl-base to 1.1.0 and replaces `conda` with `mamba`. Adds `bldocker` user and group.
