### PR TITLE
Update auto file-type detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add repo source label to Dockerfile
 - Add check for existence of index file
 ### Changed
-- Make `-t` optional, default to `file-input`
+- Make `-t` optional. Auto-detect file-types by default.
 - Explicitly set python version to `3.10`
 - Split validation and checksum generation into different CLI commands
 - Re-organize functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Make `-t` optional. Auto-detect file-types by default.
 - Explicitly set python version to `3.10`
 - Split validation and checksum generation into different CLI commands
+- Split detect extension and detect file type into separate commands
 - Re-organize functions
 ### Fixed
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,15 +4,15 @@ from validate import validate
 
 def test__detect_extension__uncompressed_files():
     '''Tests detection of all supported uncompressed extensions'''
-    assert validate.detect_extension(Path('file.something.vcf')) == '.vcf'
-    assert validate.detect_extension(Path('file.something.bed')) == '.bed'
-    assert validate.detect_extension(Path('file.something.fastq')) == '.fastq'
-    assert validate.detect_extension(Path('file.something.fq')) == '.fq'
-    assert validate.detect_extension(Path('file.something.fasta')) == '.fasta'
-    assert validate.detect_extension(Path('file.something.fa')) == '.fa'
-    assert validate.detect_extension(Path('file.something.bam')) == '.bam'
-    assert validate.detect_extension(Path('file.something.cram')) == '.cram'
-    assert validate.detect_extension(Path('file.something.sam')) == '.sam'
+    assert validate.detect_extension(Path('file.name.vcf')) == '.vcf'
+    assert validate.detect_extension(Path('file.name.bed')) == '.bed'
+    assert validate.detect_extension(Path('file.name.fastq')) == '.fastq'
+    assert validate.detect_extension(Path('file.name.fq')) == '.fq'
+    assert validate.detect_extension(Path('file.name.fasta')) == '.fasta'
+    assert validate.detect_extension(Path('file.name.fa')) == '.fa'
+    assert validate.detect_extension(Path('file.name.bam')) == '.bam'
+    assert validate.detect_extension(Path('file.name.cram')) == '.cram'
+    assert validate.detect_extension(Path('file.name.sam')) == '.sam'
 
 def test__detect_extension__script():
     '''Tests detection of script extension'''
@@ -20,10 +20,10 @@ def test__detect_extension__script():
 
 def test__detect_extension__compressed_files():
     '''Tests detection of all supported compressed full extensions'''
-    assert validate.detect_extension(Path('file.something.vcf.gz')) == '.vcf.gz'
-    assert validate.detect_extension(Path('file.something.bed.gz')) ==  '.bed.gz'
-    assert validate.detect_extension(Path('file.something.fastq.gz')) ==  '.fastq.gz'
-    assert validate.detect_extension(Path('file.something.fq.gz')) == '.fq.gz'
+    assert validate.detect_extension(Path('file.name.vcf.gz')) == '.vcf.gz'
+    assert validate.detect_extension(Path('file.name.bed.gz')) ==  '.bed.gz'
+    assert validate.detect_extension(Path('file.name.fastq.gz')) ==  '.fastq.gz'
+    assert validate.detect_extension(Path('file.name.fq.gz')) == '.fq.gz'
 
 def test__detect_file_type__vcf():
     '''Tests detection of file type from supported vcf extensions'''
@@ -55,7 +55,7 @@ def test__detect_file_type__bam():
 
 def test__detect_file_type__unknown():
     '''Tests detection of unsupported file type'''
-    assert validate.detect_file_type('.something.vcf') == 'file-unknown'
+    assert validate.detect_file_type('.name.vcf') == 'file-unknown'
 
 def test__detect_file_type__py():
     '''Tests detection of .py file type'''

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,4 +1,4 @@
-import pytest
+import unittest
 from pathlib import Path
 from validate import validate
 
@@ -47,6 +47,9 @@ def test__detect_file_type__bam():
 
 def test__detect_file_type__unknown():
     assert validate.detect_file_type('.something.vcf') == 'file-unknown'
+
+def test__detect_file_type__py():
+    assert validate.detect_file_type('.py') == 'file-py'
 
 def test__detect_file_type__unsupported_compression():
     assert validate.detect_file_type('.bam.gz') == 'file-unknown'

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,8 +1,9 @@
-import unittest
+'''Test functions in validate.py'''
 from pathlib import Path
 from validate import validate
 
 def test__detect_extension__uncompressed_files():
+    '''Tests detection of all supported uncompressed extensions'''
     assert validate.detect_extension(Path('file.something.vcf')) == '.vcf'
     assert validate.detect_extension(Path('file.something.bed')) == '.bed'
     assert validate.detect_extension(Path('file.something.fastq')) == '.fastq'
@@ -14,44 +15,53 @@ def test__detect_extension__uncompressed_files():
     assert validate.detect_extension(Path('file.something.sam')) == '.sam'
 
 def test__detect_extension__script():
+    '''Tests detection of script extension'''
     assert validate.detect_extension(Path('main.py')) == '.py'
 
 def test__detect_extension__compressed_files():
+    '''Tests detection of all supported compressed full extensions'''
     assert validate.detect_extension(Path('file.something.vcf.gz')) == '.vcf.gz'
     assert validate.detect_extension(Path('file.something.bed.gz')) ==  '.bed.gz'
     assert validate.detect_extension(Path('file.something.fastq.gz')) ==  '.fastq.gz'
     assert validate.detect_extension(Path('file.something.fq.gz')) == '.fq.gz'
 
 def test__detect_file_type__vcf():
+    '''Tests detection of file type from supported vcf extensions'''
     assert validate.detect_file_type('.vcf') == 'file-vcf'
     assert validate.detect_file_type('.vcf.gz') == 'file-vcf'
 
 def test__detect_file_type__bed():
+    '''Tests detection of file type from supported bed extensions'''
     assert validate.detect_file_type('.bed') == 'file-bed'
     assert validate.detect_file_type('.bed.gz') == 'file-bed'
 
 def test__detect_file_type__fastq():
+    '''Tests detection of file type from supported fastq extensions'''
     assert validate.detect_file_type('.fastq') == 'file-fastq'
     assert validate.detect_file_type('.fastq.gz') == 'file-fastq'
     assert validate.detect_file_type('.fq') == 'file-fastq'
     assert validate.detect_file_type('.fq.gz') == 'file-fastq'
 
 def test__detect_file_type__fasta():
+    '''Tests detection of file type from supported fasta extensions'''
     assert validate.detect_file_type('.fasta') == 'file-fasta'
     assert validate.detect_file_type('.fa') == 'file-fasta'
 
 def test__detect_file_type__bam():
+    '''Tests detection of file type from supported bam extensions'''
     assert validate.detect_file_type('.bam') == 'file-bam'
     assert validate.detect_file_type('.cram') == 'file-bam'
     assert validate.detect_file_type('.sam') == 'file-bam'
 
 def test__detect_file_type__unknown():
+    '''Tests detection of unsupported file type'''
     assert validate.detect_file_type('.something.vcf') == 'file-unknown'
 
 def test__detect_file_type__py():
+    '''Tests detection of .py file type'''
     assert validate.detect_file_type('.py') == 'file-py'
 
 def test__detect_file_type__unsupported_compression():
+    '''Tests detection of unsupported compression'''
     assert validate.detect_file_type('.bam.gz') == 'file-unknown'
     assert validate.detect_file_type('.fasta.gz') == 'file-unknown'
-

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,54 @@
+import pytest
+from pathlib import Path
+from validate import validate
+
+def test__detect_extension__uncompressed_files():
+    assert validate.detect_extension(Path('file.something.vcf')) == '.vcf'
+    assert validate.detect_extension(Path('file.something.bed')) == '.bed'
+    assert validate.detect_extension(Path('file.something.fastq')) == '.fastq'
+    assert validate.detect_extension(Path('file.something.fq')) == '.fq'
+    assert validate.detect_extension(Path('file.something.fasta')) == '.fasta'
+    assert validate.detect_extension(Path('file.something.fa')) == '.fa'
+    assert validate.detect_extension(Path('file.something.bam')) == '.bam'
+    assert validate.detect_extension(Path('file.something.cram')) == '.cram'
+    assert validate.detect_extension(Path('file.something.sam')) == '.sam'
+
+def test__detect_extension__script():
+    assert validate.detect_extension(Path('main.py')) == '.py'
+
+def test__detect_extension__compressed_files():
+    assert validate.detect_extension(Path('file.something.vcf.gz')) == '.vcf.gz'
+    assert validate.detect_extension(Path('file.something.bed.gz')) ==  '.bed.gz'
+    assert validate.detect_extension(Path('file.something.fastq.gz')) ==  '.fastq.gz'
+    assert validate.detect_extension(Path('file.something.fq.gz')) == '.fq.gz'
+
+def test__detect_file_type__vcf():
+    assert validate.detect_file_type('.vcf') == 'file-vcf'
+    assert validate.detect_file_type('.vcf.gz') == 'file-vcf'
+
+def test__detect_file_type__bed():
+    assert validate.detect_file_type('.bed') == 'file-bed'
+    assert validate.detect_file_type('.bed.gz') == 'file-bed'
+
+def test__detect_file_type__fastq():
+    assert validate.detect_file_type('.fastq') == 'file-fastq'
+    assert validate.detect_file_type('.fastq.gz') == 'file-fastq'
+    assert validate.detect_file_type('.fq') == 'file-fastq'
+    assert validate.detect_file_type('.fq.gz') == 'file-fastq'
+
+def test__detect_file_type__fasta():
+    assert validate.detect_file_type('.fasta') == 'file-fasta'
+    assert validate.detect_file_type('.fa') == 'file-fasta'
+
+def test__detect_file_type__bam():
+    assert validate.detect_file_type('.bam') == 'file-bam'
+    assert validate.detect_file_type('.cram') == 'file-bam'
+    assert validate.detect_file_type('.sam') == 'file-bam'
+
+def test__detect_file_type__unknown():
+    assert validate.detect_file_type('.something.vcf') == 'file-unknown'
+
+def test__detect_file_type__unsupported_compression():
+    assert validate.detect_file_type('.bam.gz') == 'file-unknown'
+    assert validate.detect_file_type('.fasta.gz') == 'file-unknown'
+

--- a/validate/__main__.py
+++ b/validate/__main__.py
@@ -9,8 +9,7 @@ def parse_args():
     parser.add_argument('path', help='one or more paths of files to validate', type=str, nargs='+')
     parser.add_argument('-t', '--type', help='input data type',
         choices=['file-input', 'file-bam', 'file-vcf', 'file-fasta', 'file-fastq',
-        'file-bed', 'file-py', 'directory-rw', 'directory-r'],
-        default='file-input')
+        'file-bed', 'file-py', 'directory-rw', 'directory-r'])
     parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {__version__}')
 
     parser.set_defaults(func=run_validate)

--- a/validate/__main__.py
+++ b/validate/__main__.py
@@ -8,8 +8,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('path', help='one or more paths of files to validate', type=str, nargs='+')
     parser.add_argument('-t', '--type', help='input data type',
-        choices=['file-input', 'file-bam', 'file-vcf', 'file-fasta', 'file-fastq',
-        'file-bed', 'file-py', 'directory-rw', 'directory-r'])
+        choices=['file', 'directory-rw', 'directory-r'], default='file')
     parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {__version__}')
 
     parser.set_defaults(func=run_validate)

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -17,7 +17,6 @@ DIR_TYPES = ['directory-r', 'directory-rw']
 FILE_TYPES_DICT = {'file-bam': ['.bam', '.cram', '.sam'], 'file-vcf': ['.vcf', '.vcf.gz'],
     'file-fasta': ['.fasta', '.fa'], 'file-fastq':['.fastq', '.fq.gz', '.fq', '.fastq.gz'],
     'file-bed': ['.bed', '.bed.gz'], 'file-py': ['.py']}
-GENERIC_FILE_TYPE = 'file-input' # file type needs to be detected
 UNKNOWN_FILE_TYPE = 'file-unknown' # file type is unlisted
 CHECK_FUNCTION_SWITCH = {
     'file-bam': check_bam,

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -81,13 +81,12 @@ def run_validate(args):
 
     all_files_pass = True
 
-    validation_function = validate_file
-    if args.type in DIR_TYPES:
-        validation_function = validate_dir
-
     for path in [Path(pathname) for pathname in args.path]:
         try:
-            validation_function(path)
+            if args.type in DIR_TYPES:
+                validate_dir(path, args.type)
+            else:
+                validate_file(path)
         except FileNotFoundError as file_not_found_err:
             print(f"Warning: {str(path)} {str(file_not_found_err)}")
         except (TypeError, ValueError, IOError, OSError) as err:

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -25,11 +25,9 @@ CHECK_FUNCTION_SWITCH = {
 CHECK_COMPRESSED = ['file-vcf', 'file-fastq', 'file-bed']
 COMPRESSION_TYPES = ['.gz']
 
-def validate_file(path:Path):
+def validate_file(path:Path, detected_file_type:str, file_extension:str):
     ''' Validate a single file '''
     path_exists(path)
-    file_extension = detect_extension(path)
-    detected_file_type = detect_file_type(file_extension)
 
     if not file_extension:
         raise TypeError(f'File {path} does not have a valid extension.')
@@ -83,9 +81,12 @@ def run_validate(args):
     for path in [Path(pathname) for pathname in args.path]:
         try:
             if args.type in DIR_TYPES:
-                validate_dir(path, args.type)
+                validation_type = args.type
+                validate_dir(path, validation_type)
             else:
-                validate_file(path)
+                file_extension = detect_extension(path)
+                validation_type = detect_file_type(file_extension)
+                validate_file(path, validation_type, file_extension)
         except FileNotFoundError as file_not_found_err:
             print(f"Warning: {str(path)} {str(file_not_found_err)}")
         except (TypeError, ValueError, IOError, OSError) as err:
@@ -93,7 +94,7 @@ def run_validate(args):
             print_error(path, err)
             continue
 
-        print_success(path, args.type)
+        print_success(path, validation_type)
 
     if not all_files_pass:
         sys.exit(1)

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -26,7 +26,7 @@ CHECK_FUNCTION_SWITCH = {
 CHECK_COMPRESSED = ['file-vcf', 'file-fastq', 'file-bed']
 COMPRESSION_TYPES = ['.gz']
 
-def validate_file(path:Path):
+def validate_file(path:Path, file_type:str):
     ''' Validate a single file '''
     path_exists(path)
     file_extension = detect_extension(path)
@@ -34,6 +34,12 @@ def validate_file(path:Path):
 
     if not file_extension:
         raise TypeError(f'File {path} does not have a valid extension.')
+    if (detected_file_type != UNKNOWN_FILE_TYPE and
+        file_type != GENERIC_FILE_TYPE and
+        detected_file_type != file_type):
+        raise ValueError(f'Indicated and detected file types do not match. '\
+            f'Indicated: {file_type}, detected: {detected_file_type}'
+        )
     if detected_file_type == UNKNOWN_FILE_TYPE:
         raise TypeError(f'File {file_extension} is not supported')
     if detected_file_type in CHECK_COMPRESSED:

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -10,7 +10,6 @@ from validate.files import (
     path_readable,
     path_writable
 )
-from generate_checksum.checksum import validate_checksums
 
 # Currently supported data types
 DIR_TYPES = ['directory-r', 'directory-rw']
@@ -36,7 +35,6 @@ def validate_file(path:Path, detected_file_type:str, file_extension:str):
     if detected_file_type in CHECK_COMPRESSED:
         check_compressed(path, file_extension)
 
-    validate_checksums(path)
     CHECK_FUNCTION_SWITCH.get(detected_file_type, lambda p: None)(path)
 
 def validate_dir(path:Path, dir_type:str):

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -59,7 +59,7 @@ def detect_extension(path:Path):
     # resulting extension
     full_extension = ''
     for suffix in path.suffixes[::-1]:
-        full_extension = suffix + full_extension
+        full_extension = suffix.lower() + full_extension
         if full_extension not in COMPRESSION_TYPES:
             return full_extension
     # No matching extension found so return unknown type and full extension

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -26,7 +26,7 @@ CHECK_FUNCTION_SWITCH = {
 CHECK_COMPRESSED = ['file-vcf', 'file-fastq', 'file-bed']
 COMPRESSION_TYPES = ['.gz']
 
-def validate_file(path:Path, file_type:str):
+def validate_file(path:Path):
     ''' Validate a single file '''
     path_exists(path)
     file_extension = detect_extension(path)
@@ -34,12 +34,6 @@ def validate_file(path:Path, file_type:str):
 
     if not file_extension:
         raise TypeError(f'File {path} does not have a valid extension.')
-    if (detected_file_type != UNKNOWN_FILE_TYPE and
-        file_type != GENERIC_FILE_TYPE and
-        detected_file_type != file_type):
-        raise ValueError(f'Indicated and detected file types do not match. '\
-            f'Indicated: {file_type}, detected: {detected_file_type}'
-        )
     if detected_file_type == UNKNOWN_FILE_TYPE:
         raise TypeError(f'File {file_extension} is not supported')
     if detected_file_type in CHECK_COMPRESSED:
@@ -93,7 +87,7 @@ def run_validate(args):
 
     for path in [Path(pathname) for pathname in args.path]:
         try:
-            validation_function(path, args.type)
+            validation_function(path)
         except FileNotFoundError as file_not_found_err:
             print(f"Warning: {str(path)} {str(file_not_found_err)}")
         except (TypeError, ValueError, IOError, OSError) as err:

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -10,6 +10,7 @@ from validate.files import (
     path_readable,
     path_writable
 )
+from generate_checksum.checksum import validate_checksums
 
 # Currently supported data types
 DIR_TYPES = ['directory-r', 'directory-rw']
@@ -35,6 +36,7 @@ def validate_file(path:Path, detected_file_type:str, file_extension:str):
     if detected_file_type in CHECK_COMPRESSED:
         check_compressed(path, file_extension)
 
+    validate_checksums(path)
     CHECK_FUNCTION_SWITCH.get(detected_file_type, lambda p: None)(path)
 
 def validate_dir(path:Path, dir_type:str):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->
## Checklist 

### Formatting

- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

- [ ] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

### File Updates

- [ ] I have ensured that the version number update follows the [versioning standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Docker+image+versioning+standardization).

- [ ] I have updated the version number/dependencies and added my name to the maintainer list in the `Dockerfile`.

- [ ] I have updated the version number/feature changes in the `README.md`.

<!--- This acknowledgement is optional if you do not want to be listed--->
- [ ] I have updated the version number and added my name to the contributors list in the `metadata.yaml`.

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

<!---If any previous versions have bugs, add "deprecated" in the version tag and list the bug in the corresponding release--->
- [ ] I have drafted the new version release with any additions/changes and have linked the `CHANGELOG.md` in the release. 

### Docker Hub Auto Build Rules

- [ ] I have created automated build rules following [this page](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/How+to+set+up+automated+builds+for+Docker+Hub) and I have not manually pushed this Docker image to the `blcdsdockerregistry` on [Docker Hub](https://hub.docker.com).

### Docker Image Testing

- [x] I have tested the Docker image with the `docker run` command as described below.

#### Test the Docker image with at least one sample. Verify the new Docker image works using:

```docker run -u $(id -u):$(id -g) –w <working-directory> -v <directory-you-want-to-mount>:<how-you-want-to-mount-it-within-the-docker> --rm <docker-image-name> <command-to-the-docker-with-all-parameters>```

## Description

<!--- Briefly describe the changes included in this pull request
 !--- starting with 'Closes #...' if approriate --->
 
 - refactor file-type detection and extension detection into separate functions
 - add tests for extension detection and file-type detection
 - update validation to determine file type by default from just the path
     - type arg is optional since it's redundant. function already detects file-type from the file extension.
     - remove unused generic input type from validation logic. still available as arg, but it's unused.
 - removed broken checksum check from validation. based on changelog saying they have been separated. 

Closes #...
    
<!--- Fill out the results section below with the specific test(s) conducted for this docker image.
 !--- Add additional cases as necessary.
 !--- Remove irrelevant points (depending on the docker image being tested.
 !--- Add points as necessary to completely describe the test. --->
## Testing Results

note: the checksum import and checksum function were commented out from `validate_file` function during testing.

### Nextflow Test

So far, tested vcfs with nextflow.

built image from this branch using:
```
docker build -t pipeval:nf -f docker/Dockerfile .
```

nextflow command:
```
nextflow run ./nextflow/main.nf -with-docker pipeval:nf
```

nextflow scripts located here:
```
/hot/user/mbjordan/GitHub/public-tool-PipeVal/mbjordan-nf-module/nextflow
```

nf command logs:
```
/hot/user/mbjordan/GitHub/public-tool-PipeVal/mbjordan-nf-module/work
```


### Docker

#### VCF

auto detect check:
```
I have no name!@6937253e22be:/hot/user/abeshlikyan/pipeval_testing_set$ 
validate /hot/software/pipeline/pipeline-call-MutationalSignature/Nextflow/development/input/data/_tests/ARCT/vcf/MSK-AB-0002-T14-1.vcf 
/tool/validate/files.py:9: UserWarning: Warning: file /hot/software/pipel
ine/pipeline-call-MutationalSignature/Nextflow/development/input/data/_te
sts/ARCT/vcf/MSK-AB-0002-T14-1.vcf is not zipped.
  warnings.warn(f'Warning: file {path} is not zipped.')
The header tag 'reference' not present. (Not required but highly recommended.)
INFO field at chr1
...
INFO field at chrX:153954457 .. INFO tag [AS_SB_TABLE=618,455|7,6] expec$ed different number of values (1)
INFO field at chrX:154361480 .. INFO tag [AS_SB_TABLE=851,658|10,8] expe$ted different number of values (1)
INFO field at chrX:154485887 .. INFO tag [AS_SB_TABLE=589,594|9,8] expec$ed different number of values (1)
Input: /hot/software/pipeline/pipeline-call-MutationalSignature/Nextflow$development/input/data/_tests/ARCT/vcf/MSK-AB-0002-T14-1.vcf is valid fi$e-vcf
```

backwards compatible check using file-vcf
```
I have no name!@6937253e22be:/hot/user/abeshlikyan/pipeval_testing_set$ 
validate -t file-vcf /hot/software/pipeline/pipeline-call-MutationalSignature/Nextflow/development/input/data/_tests/ARCT/vcf/MSK-AB-0002-T14-1.vcf
...
Input: /hot/software/pipeline/pipeline-call-MutationalSignature/Nextflow/
development/input/data/_tests/ARCT/vcf/MSK-AB-0002-T14-1.vcf is valid file-vcf
```

#### BAM

autodetect bam check (valid):
````
I have no name!@6937253e22be:/hot/user/abeshlikyan/pipeval_testing_set$ 
validate ./bam_pass/CPCG0196-F1-A-mini-0-RNA.bam
Input: bam_pass/CPCG0196-F1-A-mini-0-RNA.bam is valid file-bam
````

autodetect bam check (invalid - empty):
```
I have no name!@6937253e22be:/hot/user/abeshlikyan/pipeval_testing_set$
 validate ./bam_fail_empty/HG002_N_A-null.bam
Error: bam_fail_empty/HG002_N_A-null.bam pysam bam check failed. No reads in bam_fail_empty/HG002_N_A-null.bam
```

autodetect bam check (invalid):
```
I have no name!@6937253e22be:/hot/user/abeshlikyan/pipeval_testing_set$ 
validate ./bam_fail_invalid/invalid.bam     
Error: bam_fail_invalid/invalid.bam samtools bam check failed. 'samtools returned with error 4: stdout=, stderr=bam_fail_invalid/invalid.bam was not identified as sequence data.\n'
```

autodetect bam check (warning on missing index):
```
I have no name!@6937253e22be:/hot/user/abeshlikyan/pipeval_testing_set$ 
validate ./bam_warn_index_missing/CPCG0196-F1-A-mini-0-RNA.bam 
Warning: bam_warn_index_missing/CPCG0196-F1-A-mini-0-RNA.bam pysam bam index check failed. Index file for bam_warn_index_missing/CPCG0196-F1-A-mini-0-RNA.bamcould not be opened or does not exist.
Input: bam_warn_index_missing/CPCG0196-F1-A-mini-0-RNA.bam is valid file-bam
```

backwards compatible check (of valid file):
```
I have no name!@6937253e22be:/hot/user/abeshlikyan/pipeval_testing_set$ 
validate -t file-bam ./bam_pass/CPCG0196-F1-A-mini-0-RNA.bam
Input: bam_pass/CPCG0196-F1-A-mini-0-RNA.bam is valid file-bam
```

backwards compatible check (of invalid file):
```
I have no name!@6937253e22be:/hot/user/abeshlikyan/pipeval_testing_set$ 
validate -t file-bam bam_fail_invalid/invalid.bam
Error: bam_fail_invalid/invalid.bam samtools bam check failed. 'samtools returned with error 4: stdout=, stderr=bam_fail_invalid/invalid.bam was not identified as sequence data.\n'
```