### PR TITLE
Fix missing checksum module in dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Explicitly set python version to `3.10`
 - Split validation and checksum generation into different CLI commands
 - Re-organize functions
+- Change builder image to mambaforge in Dockerfile
+
 ### Fixed
 
 ---

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,7 @@
-FROM blcdsdockerregistry/bl-base:1.1.0 AS builder
+ARG MINIFORGE_VERSION=22.9.0-2
+ARG UBUNTU_VERSION=20.04
+
+FROM condaforge/mambaforge:${MINIFORGE_VERSION} AS builder
 
 # Use conda to install tools and dependencies into /usr/local
 ARG PYTHON_VERSION=3.10
@@ -13,7 +16,7 @@ RUN mamba create -qy -p /usr/local \
     pip
 
 # Deploy the target tools into a base image
-FROM ubuntu:20.04
+FROM ubuntu:${UBUNTU_VERSION} AS final
 COPY --from=builder /usr/local /usr/local
 
 # create directory for python script

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir -p /tool/validate/
 COPY setup.py /tool
 COPY setup.cfg /tool
 COPY pyproject.toml /tool
+COPY /generate_checksum /tool/generate_checksum
 COPY /validate/ /tool/validate/
 WORKDIR /tool
 RUN pip install build && \

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@
 category: 'tool'
 description: 'PipeVal'
 maintainers: ['yashpatel@mednet.ucla.edu']
-contributors: ['Arpi Beshlikyan', 'Yash Patel']
+contributors: ['Arpi Beshlikyan', 'Yash Patel', 'Madison Jordan', 'Gina Kim']
 languages: ['python', 'Dockerfile']
 version: ['3.0.0']
 purpose_of_tool: 'Validates different parameters in NF scripts/pipelines'


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->
## Checklist 

### Formatting

- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].

- [x] I have set up or verified the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

### File Updates

- [ ] I have ensured that the version number update follows the [versioning standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Docker+image+versioning+standardization).

- [ ] I have updated the version number/dependencies and added my name to the maintainer list in the `Dockerfile`.

- [ ] I have updated the version number/feature changes in the `README.md`.

<!--- This acknowledgement is optional if you do not want to be listed--->
- [ ] I have updated the version number and added my name to the contributors list in the `metadata.yaml`.

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

<!---If any previous versions have bugs, add "deprecated" in the version tag and list the bug in the corresponding release--->
- [ ] I have drafted the new version release with any additions/changes and have linked the `CHANGELOG.md` in the release. 

### Docker Hub Auto Build Rules

- [ ] I have created automated build rules following [this page](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/How+to+set+up+automated+builds+for+Docker+Hub) and I have not manually pushed this Docker image to the `blcdsdockerregistry` on [Docker Hub](https://hub.docker.com).

### Docker Image Testing

- [x] I have tested the Docker image with the `docker run` command as described below.

#### Test the Docker image with at least one sample. Verify the new Docker image works using:

```docker run -u $(id -u):$(id -g) –w <working-directory> -v <directory-you-want-to-mount>:<how-you-want-to-mount-it-within-the-docker> --rm <docker-image-name> <command-to-the-docker-with-all-parameters>```

#### My command: 

```Provide the command you ran here```

## Description

<!--- Briefly describe the changes included in this pull request
 !--- starting with 'Closes #...' if approriate --->

Closes #65 
    
<!--- Fill out the results section below with the specific test(s) conducted for this docker image.
 !--- Add additional cases as necessary.
 !--- Remove irrelevant points (depending on the docker image being tested.
 !--- Add points as necessary to completely describe the test. --->
## Testing Results

checksum 
```
I have no name!@63615425fcd9:/hot/software/pipeli
ne/pipeline-call-MutationalSignature/Nextflow/dev
elopment/input/data/_tests/ARCT/vcf$ 
generate-checksum -t md5 ./MSK-AB-0002-T14-1.vcf 
md5 checksum generated for MSK-AB-0002-T14-1.vcf
```

validation:
```
I have no name!@63615425fcd9:/hot/software/pipeli
ne/pipeline-call-MutationalSignature/Nextflow/dev
elopment/input/data/_tests/ARCT/vcf$ 
validate MSK-AB-0002-T14-1.vcf 
...
Input: MSK-AB-0002-T14-1.vcf is valid file-input
```