### PR TITLE
Automatic detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Removed 
 - Remove deprecated parameter options from README
 - Remove inaccessible design doc link from README
+- Remove directory checking
+- Remove user-specified file type option
+
 ---
 
 ## [3.0.0] - 2022-08-03

--- a/validate/__main__.py
+++ b/validate/__main__.py
@@ -7,10 +7,6 @@ def parse_args():
     """ Parse arguments """
     parser = argparse.ArgumentParser()
     parser.add_argument('path', help='one or more paths of files to validate', type=str, nargs='+')
-    parser.add_argument('-t', '--type', help='input data type',
-        choices=['file-input', 'file-bam', 'file-vcf', 'file-fasta', 'file-fastq',
-        'file-bed', 'file-py', 'directory-rw', 'directory-r'],
-        default='file-input')
     parser.add_argument('-v', '--version', action='version', version=f'%(prog)s {__version__}')
 
     parser.set_defaults(func=run_validate)

--- a/validate/files.py
+++ b/validate/files.py
@@ -12,15 +12,3 @@ def path_exists(path:Path):
     ''' Check if path exists '''
     if not path.exists():
         raise IOError('File or directory does not exist.')
-
-def path_readable(path:Path):
-    '''Checks if path is readable'''
-    if os.access(path, os.R_OK):
-        return True
-    raise IOError('File or directory is not readable.')
-
-def path_writable(path:Path):
-    '''Checks if path is writable'''
-    if os.access(path, os.W_OK):
-        return True
-    raise IOError('File or directory is not writable.')

--- a/validate/files.py
+++ b/validate/files.py
@@ -5,8 +5,9 @@ import warnings
 
 def check_compressed(path:Path, file_extension:str):
     ''' Check file is compressed '''
-    if not file_extension.endswith('.gz'):
-        warnings.warn(f'Warning: file {path} is not zipped.')
+    compression_extensions = ['.gz']
+    if not any([file_extension.endswith(ext) for ext in compression_extensions]):
+        warnings.warn(f'Warning: file {path} is not compressed.')
 
 def path_exists(path:Path):
     ''' Check if path exists '''

--- a/validate/files.py
+++ b/validate/files.py
@@ -1,12 +1,11 @@
 ''' File checking functions '''
 from pathlib import Path
-import os
 import warnings
 
 def check_compressed(path:Path, file_extension:str):
     ''' Check file is compressed '''
     compression_extensions = ['.gz']
-    if not any([file_extension.endswith(ext) for ext in compression_extensions]):
+    if not any(file_extension.endswith(ext) for ext in compression_extensions):
         warnings.warn(f'Warning: file {path} is not compressed.')
 
 def path_exists(path:Path):

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -6,9 +6,7 @@ from validate.validators.bam import check_bam
 from validate.validators.vcf import check_vcf
 from validate.files import (
     check_compressed,
-    path_exists,
-    path_readable,
-    path_writable
+    path_exists
 )
 from generate_checksum.checksum import validate_checksums
 
@@ -46,12 +44,6 @@ def validate_file(path:Path, file_type:str):
 
     CHECK_FUNCTION_SWITCH.get(detected_file_type, lambda p: None)(path)
 
-def validate_dir(path:Path, dir_type:str):
-    ''' Validate directory '''
-    path_readable(path)
-    if dir_type == 'directory-rw':
-        path_writable(path)
-
 def print_error(path:Path, err:BaseException):
     ''' Prints error message '''
     print(f'Error: {str(path)} {str(err)}')
@@ -88,13 +80,9 @@ def run_validate(args):
 
     all_files_pass = True
 
-    validation_function = validate_file
-    if args.type in DIR_TYPES:
-        validation_function = validate_dir
-
     for path in [Path(pathname) for pathname in args.path]:
         try:
-            validation_function(path, args.type)
+            validate_file(path, args.type)
         except FileNotFoundError as file_not_found_err:
             print(f"Warning: {str(path)} {str(file_not_found_err)}")
         except (TypeError, ValueError, IOError, OSError) as err:

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -21,20 +21,19 @@ CHECK_FUNCTION_SWITCH = {
 }
 CHECK_COMPRESSION_TYPES = ['file-vcf', 'file-fastq', 'file-bed']
 
-def validate_file(path:Path):
+def validate_file(path:Path, file_type:str, file_extension:str):
     ''' Validate a single file '''
     path_exists(path)
 
-    detected_file_type, file_extension = detect_file_type_and_extension(path)
     if not file_extension:
         raise TypeError(f'File {path} does not have a valid extension.')
 
-    if detected_file_type in CHECK_COMPRESSION_TYPES:
+    if file_type in CHECK_COMPRESSION_TYPES:
         check_compressed(path, file_extension)
 
     validate_checksums(path)
 
-    CHECK_FUNCTION_SWITCH.get(detected_file_type, lambda p: None)(path)
+    CHECK_FUNCTION_SWITCH.get(file_type, lambda p: None)(path)
 
 def print_error(path:Path, err:BaseException):
     ''' Prints error message '''
@@ -74,7 +73,8 @@ def run_validate(args):
 
     for path in [Path(pathname) for pathname in args.path]:
         try:
-            validate_file(path)
+            file_type, file_extension = detect_file_type_and_extension(path)
+            validate_file(path, file_type, file_extension)
         except FileNotFoundError as file_not_found_err:
             print(f"Warning: {str(path)} {str(file_not_found_err)}")
         except (TypeError, ValueError, IOError, OSError) as err:
@@ -82,7 +82,7 @@ def run_validate(args):
             print_error(path, err)
             continue
 
-        print_success(path, args.type)
+        print_success(path, file_type)
 
     if not all_files_pass:
         sys.exit(1)


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->

Removing directory validation
Removing user-specified option for file type and letting tool automatically determine file type

---
## Test Results

<!--- Please test the following in a built docker image.  --->


### Validation Test

```bash
#!/bin/bash
echo "empty BAM"
validate  /hot/user/abeshlikyan/pipeval_testing_set/bam_fail_empty/HG002_N_A-null.bam

printf "\n"

echo "invalid BAM"
validate  /hot/user/abeshlikyan/pipeval_testing_set/bam_fail_invalid/invalid.bam

printf "\n"

echo "pass BAM"
validate  /hot/user/abeshlikyan/pipeval_testing_set/bam_pass/CPCG0196-F1-A-mini-0-RNA.bam

printf "\n"

echo "BAM with no index"
validate  /hot/user/abeshlikyan/pipeval_testing_set/bam_warn_index_missing/CPCG0196-F1-A-mini-0-RNA.bam

printf "\n"

echo "Just text file"
validate  /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/hello.txt

printf "\n"

echo "Failing checksum MD5"
validate  /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/hello_bad_md5.txt

echo "Failing checksum SHA512"
validate  /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/hello_bad_sha512.txt

printf "\n"

echo "Generate md5 checksum"
generate-checksum -t md5 /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/togen.txt

echo "Generate sha512 checksum"
generate-checksum -t sha512 /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/togen.txt

echo "Validate generated checksums"
validate /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/togen.txt

printf "\n"

echo "Valid VCF"
validate  /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/test_vcf.vcf.gz

```

---

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

### File Commits

- [X] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [X] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.

- [X] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

### Code Review Best Practices

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

### Testing

- [ ] I have added unit tests for the new feature(s).

- [ ] I modified the integration test(s) to include the new feature.

- [X] All new and previously existing tests passed locally and/or on the cluster.

- [X] The docker image built successfully on the cluster.
