### PR TITLE
Add tests for main runner functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ pip-delete-this-directory.txt
 venv
 .venv
 .env
+.coverage
 # setup.py working directory
 build
 # setup.py dist directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add check for existence of index file
 - Add references for VCFtools and Pysam in README
 - Unit tests for existing functions
+- Unit tests for main runner functions
 
 ### Changed
 - Make `-t` optional, default to `file-input`

--- a/generate_checksum/checksum.py
+++ b/generate_checksum/checksum.py
@@ -71,11 +71,9 @@ def generate_checksum(args):
         except KeyError as key_err:
             all_checksums_generated = False
             print(f'Invalid checksum type. {str(key_err)}')
-            continue
         except (IOError, PermissionError, OSError, FileNotFoundError) as err:
             all_checksums_generated = False
             print(f'Failed to write checksum for {str(path)}: {str(err)}')
-            continue
 
         if not all_checksums_generated:
             sys.exit(1)

--- a/generate_checksum/checksum.py
+++ b/generate_checksum/checksum.py
@@ -75,5 +75,5 @@ def generate_checksum(args):
             all_checksums_generated = False
             print(f'Failed to write checksum for {str(path)}: {str(err)}')
 
-        if not all_checksums_generated:
-            sys.exit(1)
+    if not all_checksums_generated:
+        sys.exit(1)

--- a/test/unit/test_generate_checksum.py
+++ b/test/unit/test_generate_checksum.py
@@ -145,7 +145,7 @@ def test__generate_sha512__return_correct_checksum(mock_iter, mock_path, mock_re
     ]
 )
 @mock.patch('generate_checksum.checksum.Path', autospec=True)
-def test__generate_checksum__calls_passes_generation_no_files(mock_path, test_args):
+def test__generate_checksum__passes_generation_no_files(mock_path, test_args):
     generate_checksum(test_args)
 
 @mock.patch('generate_checksum.checksum.Path', autospec=True)

--- a/test/unit/test_generate_checksum.py
+++ b/test/unit/test_generate_checksum.py
@@ -2,6 +2,7 @@
 # pylint: disable=C0114
 from unittest.mock import mock_open
 import hashlib
+from types import SimpleNamespace
 import mock
 import pytest
 
@@ -10,7 +11,8 @@ from generate_checksum.checksum import (
     compare_hash,
     write_checksum_file,
     generate_md5,
-    generate_sha512
+    generate_sha512,
+    generate_checksum
 )
 
 @mock.patch('generate_checksum.checksum.Path', autospec=True)
@@ -134,3 +136,49 @@ def test__generate_sha512__return_correct_checksum(mock_iter, mock_path, mock_re
     mock_iter.return_value = iter([b''])
 
     assert generate_sha512(mock_path) == sha512_checksum.hexdigest()
+
+@pytest.mark.parametrize(
+    'test_args',
+    [
+        (SimpleNamespace(path=[], type='md5')),
+        (SimpleNamespace(path=[], type='sha512'))
+    ]
+)
+@mock.patch('generate_checksum.checksum.Path', autospec=True)
+def test__generate_checksum__calls_passes_generation_no_files(mock_path, test_args):
+    generate_checksum(test_args)
+
+@mock.patch('generate_checksum.checksum.Path', autospec=True)
+def test__generate_checksum__fails_with_invalid_type(mock_path):
+    test_args = SimpleNamespace(path=['some/path'], type='bad_type')
+    expected_code = 1
+
+    with pytest.raises(SystemExit) as pytest_exit:
+        generate_checksum(test_args)
+    assert pytest_exit.value.code == expected_code
+
+@pytest.mark.parametrize(
+    'test_args',
+    [
+        (SimpleNamespace(path=['some/path'], type='md5')),
+        (SimpleNamespace(path=['some/path'], type='sha512'))
+    ]
+)
+@mock.patch('generate_checksum.checksum.Path', autospec=True)
+@mock.patch('generate_checksum.checksum.generate_md5')
+@mock.patch('generate_checksum.checksum.generate_sha512')
+@mock.patch('generate_checksum.checksum.write_checksum_file')
+def test__generate_checksum__fails_with_failed_write(
+    mock_write_checksum_file,
+    mock_generate_sha512,
+    mock_generate_md5,
+    mock_path,
+    test_args):
+    mock_generate_md5.return_value = ''
+    mock_generate_sha512.return_value = ''
+    mock_write_checksum_file.side_effect = IOError('fail write')
+    expected_code = 1
+
+    with pytest.raises(SystemExit) as pytest_exit:
+        generate_checksum(test_args)
+    assert pytest_exit.value.code == expected_code

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -130,8 +130,7 @@ def test__validate_vcf_file__passes_vcf_validation(mock_call):
     validate_vcf_file('some/file')
 
 @mock.patch('validate.validate.print_success')
-@mock.patch('validate.validate.Path', autospec=True)
-def test__run_validate__passes_validation_no_files(mock_print_success, mock_path):
+def test__run_validate__passes_validation_no_files(mock_print_success):
     test_args = SimpleNamespace(path=[])
     mock_print_success.return_value = ''
     run_validate(test_args)
@@ -148,9 +147,7 @@ def test__run_validate__passes_validation_no_files(mock_print_success, mock_path
 @mock.patch('validate.validate.detect_file_type_and_extension')
 @mock.patch('validate.validate.validate_file')
 @mock.patch('validate.validate.print_error')
-@mock.patch('validate.validate.Path', autospec=True)
 def test__run_validate__fails_with_failing_checks(
-    mock_path,
     mock_print_error,
     mock_validate_file,
     mock_detect_file_type_and_extension,


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->

Adding tests for the main runner functions that loop over the input files.
Increases the test coverage to 95%

---

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

### File Commits

- [X] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [X] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.

- [X] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

### Code Review Best Practices

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

### Testing

- [X] I have added unit tests for the new feature(s).

- [ ] I modified the integration test(s) to include the new feature.

- [X] All new and previously existing tests passed locally and/or on the cluster.

- [ ] The docker image built successfully on the cluster.
