### PR TITLE
Compression checks and detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Unit tests for existing functions
 - Unit tests for main runner functions
 - Add separate checks for SAM and CRAM files
+- Compression validation and detection through `python-magic`
 
 ### Changed
 - Make `-t` optional, default to `file-input`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,11 @@ RUN mamba create -qy -p /usr/local \
 FROM ubuntu:${UBUNTU_VERSION} AS final
 COPY --from=builder /usr/local /usr/local
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libmagic1 && \
+    rm -rf /var/lib/apt/lists/ && \
+    rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+
 # create directory for python script
 RUN mkdir -p /tool/validate/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=builder /usr/local /usr/local
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagic1 && \
-    rm -rf /var/lib/apt/lists/ && \
+    rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 # create directory for python script

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,9 @@ python_requires = >=3.6
 
 install_requires =
     mock==4.0.2
-    pytest==6.2.5
+    pytest==7.2.2
     pysam==0.19.0
+    python-magic==0.4.27
 
 [options.packages.find]
 where = .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [metadata]
 name = validate
 version = attr: validate.__version__
-author = 'Arpi Beshlikyan'
-author_email = 'ABeshlikyan@mednet.ucla.edu'
+author = 'Yash Patel'
+author_email = 'YashPatel@mednet.ucla.edu'
 description = 'Python CLI tool to validate different file types and their contents in Nextflow scripts/pipelines'
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -77,7 +77,6 @@ def test__path_exists__errors_for_non_existing_path(mock_path):
 @mock.patch('validate.files.magic.from_file')
 @mock.patch('validate.files.Path', autospec=True)
 def test__check_compressed__raises_warning_for_uncompressed_path(mock_path, mock_magic):
-    test_extension = '.vcf'
     mock_magic.return_value = 'text/plain'
 
     with pytest.warns(UserWarning):

--- a/test/unit/test_validate.py
+++ b/test/unit/test_validate.py
@@ -74,20 +74,30 @@ def test__path_exists__errors_for_non_existing_path(mock_path):
     with pytest.raises(IOError):
         path_exists(mock_path)
 
+@mock.patch('validate.files.magic.from_file')
 @mock.patch('validate.files.Path', autospec=True)
-def test__check_compressed__raises_warning_for_uncompressed_path(mock_path):
+def test__check_compressed__raises_warning_for_uncompressed_path(mock_path, mock_magic):
     test_extension = '.vcf'
+    mock_magic.return_value = 'text/plain'
 
     with pytest.warns(UserWarning):
-        check_compressed(mock_path, test_extension)
+        check_compressed(mock_path)
 
+@pytest.mark.parametrize(
+    'compression_mime',
+    [
+        ('application/x-gzip'),
+        ('application/x-bzip2')
+    ]
+)
+@mock.patch('validate.files.magic.from_file')
 @mock.patch('validate.files.Path', autospec=True)
-def test__check_compressed__passes_compression_check(mock_path):
-    test_extension = '.vcf.gz'
+def test__check_compressed__passes_compression_check(mock_path, mock_magic, compression_mime):
+    mock_magic.return_value = compression_mime
 
     with warnings.catch_warnings():
         warnings.filterwarnings("error")
-        check_compressed(mock_path, test_extension)
+        check_compressed(mock_path)
 
 @mock.patch('validate.validators.bam.pysam')
 def test__validate_bam_file__empty_bam_file(mock_pysam):

--- a/validate/files.py
+++ b/validate/files.py
@@ -1,11 +1,15 @@
 ''' File checking functions '''
 from pathlib import Path
 import warnings
+import magic
 
-def check_compressed(path:Path, file_extension:str):
+def check_compressed(path:Path):
     ''' Check file is compressed '''
-    compression_extensions = ['.gz']
-    if not any(file_extension.endswith(ext) for ext in compression_extensions):
+    compression_mimes = [
+        'application/x-gzip',
+        'application/x-bzip2'
+    ]
+    if magic.from_file(path.resolve(), mime=True) not in compression_mimes:
         warnings.warn(f'Warning: file {path} is not compressed.')
 
 def path_exists(path:Path):

--- a/validate/validate.py
+++ b/validate/validate.py
@@ -49,7 +49,7 @@ def validate_file(
         raise TypeError(f'File {path} does not have a valid extension.')
 
     if file_type in CHECK_COMPRESSION_TYPES:
-        check_compressed(path, file_extension)
+        check_compressed(path)
 
     validate_checksums(path)
 


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->

Closes #53 
Closes #73 

Adding validation and checks for compressed files through `python-magic`

---
## Test Results

```
#!/bin/bash
echo "empty BAM"
validate  /hot/user/abeshlikyan/pipeval_testing_set/bam_fail_empty/HG002_N_A-null.bam

printf "\n"

echo "invalid BAM"
validate  /hot/user/abeshlikyan/pipeval_testing_set/bam_fail_invalid/invalid.bam

printf "\n"

echo "pass BAM"
validate  /hot/user/abeshlikyan/pipeval_testing_set/bam_pass/CPCG0196-F1-A-mini-0-RNA.bam

printf "\n"

echo "BAM with no index"
validate  /hot/user/abeshlikyan/pipeval_testing_set/bam_warn_index_missing/CPCG0196-F1-A-mini-0-RNA.bam

printf "\n"

echo "Just text file"
validate  /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/hello.txt

printf "\n"

echo "Failing checksum MD5"
validate  /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/hello_bad_md5.txt

echo "Failing checksum SHA512"
validate  /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/hello_bad_sha512.txt

printf "\n"

echo "Generate md5 checksum"
generate-checksum -t md5 /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/togen.txt

echo "Generate sha512 checksum"
generate-checksum -t sha512 /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/togen.txt

echo "Validate generated checksums"
validate /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/togen.txt

printf "\n"

echo "Valid VCF"
validate  /hot/user/yashpatel/public-tool-PipeVal/public-tool-PipeVal/work/test_vcf.vcf.gz

printf "\n"

echo "Valid CRAM"
validate /hot/software/pipeline/pipeline-call-gSNP/Nextflow/development/input/data/formats/TCEB1_RCC_S00-9422N_079_114_0.1.cram -r /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta

printf "\n"

echo "CRAM with no index"
validate /hot/software/pipeline/pipeline-call-gSNP/Nextflow/development/input/data/formats/cram_but_no_index.cram -r /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta

printf "\n"

echo "CRAM with default reference"
validate /hot/software/pipeline/pipeline-call-gSNP/Nextflow/development/input/data/formats/small.cram

printf "\n"

echo "Invalid CRAM"
validate /hot/software/pipeline/pipeline-call-gSNP/Nextflow/development/input/data/formats/a.cram -r /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta

printf "\n"

echo "Valid SAM"
validate /hot/software/pipeline/pipeline-call-gSNP/Nextflow/development/input/data/formats/TCEB1_RCC_S00-9422N_079_114_0.1.sam

```

---

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

### File Commits

- [X] This PR **does *NOT* contain** Protected Health Information [(PHI)](https://ohrpp.research.ucla.edu/hipaa/). A repo may ***need to be deleted*** if such data is uploaded. <br> Disclosing PHI is a ***major problem***[^1] - Even ***a small leak can be costly***[^2].
  
- [X] This PR **does *NOT* contain** germline genetic data[^3], RNA-Seq, DNA methylation, microbiome or other molecular data[^4].

[^1]: [UCLA Health reaches $7.5m settlement over 2015 breach of 4.5m patient records](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m)
[^2]: [The average healthcare data breach costs $2.2 million, despite the majority of breaches releasing fewer than 500 records.](https://www.ponemon.org/local/upload/file/Sixth%20Annual%20Patient%20Privacy%20%26%20Data%20Security%20Report%20FINAL%206.pdf)
[^3]: [Genetic information is considered PHI.](https://www.genome.gov/about-genomics/policy-issues/Privacy#:~:text=In%202013%2C%20as%20required%20by,genetic%20information%20for%20underwriting%20purposes.)
  [Forensic assays can identify patients with as few as 21 SNPs](https://www.sciencedirect.com/science/article/pii/S1525157817305962)
[^4]: [RNA-Seq](https://www.nature.com/articles/ng.2248), [DNA methylation](https://ieeexplore.ieee.org/document/7958619), [microbiome](https://www.pnas.org/doi/pdf/10.1073/pnas.1423854112), or other molecular data can be used to predict genotypes (PHI) and reveal a patient's identity.

- [X] This PR **does *NOT* contain** other non-plain text files, such as: compressed files, images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other output files.

_&emsp; To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example._

### Code Review Best Practices

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
  
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

### Testing

- [X] I have added unit tests for the new feature(s).

- [ ] I modified the integration test(s) to include the new feature.

- [X] All new and previously existing tests passed locally and/or on the cluster.

- [X] The docker image built successfully on the cluster.
